### PR TITLE
Fix a Little Typo!

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -12,7 +12,7 @@ function Header(ctx) {
       delete headers['x-forwarded-proto']
       //request.headers['host'] = new URL(ctx.encoding.decode(request.url.replace(ctx.prefix, ''))).hostname
       headers['origin'] = new URL(ctx.encoding.decode(request.url.replace(ctx.prefix, ''))).origin
-      headers['referrer'] = new URL(ctx.encoding.decode(request.url.replace(ctx.prefix, ''))).href
+      headers['referer'] = new URL(ctx.encoding.decode(request.url.replace(ctx.prefix, ''))).href
       if (ctx.userAgent) request.headers['user-agent'] = ctx.userAgent
       return headers
     },


### PR DESCRIPTION
The original specification for HTTP/1.0 misspelled referrer so now we all have too :) https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer